### PR TITLE
Fixup tornado_patch to use tornado's gen.coroutines

### DIFF
--- a/kafkaka/define.py
+++ b/kafkaka/define.py
@@ -18,6 +18,10 @@ class KafkaError(Exception):
     pass
 
 
+class TopicError(Exception):
+    pass
+
+
 class ConnectionError(KafkaError):
     """
     socket connection error

--- a/kafkaka/tornado_patch.py
+++ b/kafkaka/tornado_patch.py
@@ -3,60 +3,34 @@ from itertools import chain
 import logging
 import struct
 import socket
-from time import sleep
-from functools import partial
-from kafkaka.client import KafkaClient
-from kafkaka.conn import Connection
-from kafkaka.define import DEFAULT_POOL_SIZE, KafkaError, ConnectionError
-from tornado.iostream import IOStream
+import time
+from collections import deque
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
+from tornado import iostream
+from tornado import gen
+
+from kafkaka.define import DEFAULT_SOCKET_TIMEOUT_SECONDS, DEFAULT_RETRY_TIMES
+from kafkaka.client import KafkaClient as BaseKafkaClient
+from kafkaka.conn import Connection as BaseConnection
+from kafkaka.define import KafkaError, ConnectionError, TopicError
+
+
+logging.basicConfig(
+    format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG
+)
 log = logging.getLogger("kafka")
 
 
-class Gen():
-
-    def __init__(self):
-        pass
-
-    @staticmethod
-    def task(func, *args, **kwargs):
-        # pack the function to be executed later
-        return partial(func, *args, **kwargs)
-
-    @staticmethod
-    def callback(g, response=None):
-        try:
-            f = g.send(response)
-            if hasattr(f, '__call__'):
-                f(partial(Gen.callback, g))  # for multiple yield
-        except StopIteration:
-            pass
-
-    @staticmethod
-    def async(func):
-        def wrapper(*args, **kwargs):
-            g = func(*args, **kwargs)
-            try:
-                f = g.send(None)
-            except StopIteration:
-                pass
-            else:
-                if hasattr(f, '__call__'):
-                    f(partial(Gen.callback, g))  # pack the generater in callback for later use
-        return wrapper
-
-gen = Gen()
-
-
-class Connection(Connection):
+class Connection(BaseConnection):
 
     def __init__(self, pool=None, *args, **kwargs):
+        self._ready = False
         super(Connection, self).__init__(*args, **kwargs)
         self._pool = pool
         self._stream = None
         self._callbacks = []
-        self._ready = False
+        self._work = deque()
+        self._working = False
 
     def __enter__(self):
         return self
@@ -64,83 +38,130 @@ class Connection(Connection):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._pool.release(self)
 
-    def _add_callback(self, func):
-        self._callbacks.append(func)
-
-    def _do_callbacks(self):
-        self._ready = True
-        while 1:
-            try:
-                func = self._callbacks.pop()
-                func()
-            except IndexError:
-                # all done
-                break
-            except:
-                # other error
-                continue
-
+    @gen.coroutine
     def connect(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        self._sock = IOStream(s)  # tornado iostream
-        self._sock.connect((self._host, self._port), self._do_callbacks)
+        # this has to be replaced by a call to "start" so that the async is
+        # properly handled
+        pass
 
-    def send(self, payload, correlation_id=-1, callback=None):
+    @gen.coroutine
+    def start(self):
+        """
+        Replaces `connect` for async operations.  The connection pool
+        is now responsible not just for instantiation of a new connection
+        but also of invoking "start" in some async context to guarnatee
+        the connection is active before returing it.
+        """
+        try:
+            if not self._ready:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+                logging.debug("connecting: %r", self)
+                self._sock = iostream.IOStream(s)  # tornado iostream
+                yield self._sock.connect((self._host, self._port))
+                logging.debug("connected: %r", self)
+                self._ready = True
+        except (socket.error, socket.timeout):
+            yield self.close()
+            self._log_and_raise("Unable to connect to kafka broker")
+
+    @gen.coroutine
+    def do_work(self):
+        """
+        Requests and responses over the connection are serial, so keep all of
+        the send and recv messages in the same place and orderly.
+
+        This function guarantees there is only one sender and one reciever
+        running at a time, and that the response is passed back into the
+        proper future.
+        """
+        while not self._working and self._work:
+            self._working = True
+            try:
+                payload, correlation_id, future = self._work.popleft()
+                yield self.send(payload, correlation_id)
+                res = yield self.recv(correlation_id)
+                future.set_result(res)
+            finally:
+                self._working = False
+
+    def communicate(self, payload, correlation_id=-1):
+        """
+        Entrypoint for bidirectional communication.
+
+        :param payload: an encoded kafka packet
+        :param correlation_id: for now, just for debug logging
+        :return: kafka response packet.
+        """
+        future = gen.Future()
+        self._work.append((payload, correlation_id, future))
+        self.do_work()
+        return future
+
+    @gen.coroutine
+    def send(self, payload, correlation_id=-1):
         """
         :param payload: an encoded kafka packet
         :param correlation_id: for now, just for debug logging
         :return:
         """
-        if not self._ready:
-            def _callback(*args, **kwargs):
-                self.send(payload, correlation_id, callback)
-            self._add_callback(_callback)
-            return
-        log.debug("About to send %d bytes to Kafka, request %d" % (len(payload), correlation_id))
+        log.debug(
+            "About to send %d bytes to Kafka, request %d" %
+            (len(payload), correlation_id)
+        )
         if payload:
             _bytes = struct.pack('>i%ds' % len(payload), len(payload), payload)
         else:
             _bytes = struct.pack('>i', -1)
         try:
-            self._sock.write(_bytes, callback)  # simply using sendall
-        except:
+            res = yield self._sock.write(_bytes)
+        except Exception:
             self.close()
-            callback(None)
             self._log_and_raise('Unable to send payload to Kafka')
+        else:
+            raise gen.Return(res)
 
-    def _recv(self, size, callback):
+    @gen.coroutine
+    def recv_chunk(self, chunk_size):
         try:
-            self._sock.read_bytes(min(size, 4096), callback)
-        except:
+            res = yield self._sock.read_bytes(min(chunk_size, 4096))
+        except Exception:
             self.close()
-            callback(None)  # if error, set None
             self._log_and_raise('Unable to receive data from Kafka')
+        else:
+            raise gen.Return(res)
 
-    def recv(self, correlation_id=-1, callback=None):
+    @gen.coroutine
+    def recv(self, correlation_id=-1):
         """
-
         :param correlation_id: for now, just for debug logging
         :return: kafka response packet
         """
-        log.debug("Reading response %d from Kafka" % correlation_id)
-        if not self._ready:
-            def _callback():
-                self.recv(correlation_id, callback)
-            self._add_callback(_callback)
-            return
-        def get_size(resp):
-            if resp == None:
-                callback(None)
+        log.debug("Reading response #%d from Kafka", correlation_id)
+        resp = yield self.recv_chunk(4)
+        log.debug(
+            "Got %d bytes header back from Kafka for #%d: %s",
+            len(resp) if resp else 0,
+            correlation_id,
+            "FAIL" if not resp else "SUCCESS"
+        )
+        if not resp:
+            raise gen.Return(None)
+        else:
             size, = struct.unpack('>i', resp)
-            self._recv(size, callback)
-        self._recv(4, get_size)  # read the response length
+            resp = yield self.recv_chunk(size)
+            log.debug(
+                "Got %d bytes response back from Kafka for #%d",
+                len(resp) if resp else 0,
+                correlation_id
+            )
+            raise gen.Return(resp)
 
     def close(self):
-        self._callbacks = []
         log.debug("Closing socket connection" + self._log_tail)
         if self._sock:
             self._sock.close()
             self._sock = None
+            self._ready = False
         else:
             log.debug("Socket connection not exists" + self._log_tail)
 
@@ -150,6 +171,12 @@ class Connection(Connection):
 
 class ConnectionPool(object):
     def __init__(self, connection_class=Connection, **connection_kwargs):
+        self.retry_times = connection_kwargs.pop(
+            "retry_times", DEFAULT_RETRY_TIMES
+        )
+        self.timeout = connection_kwargs.pop(
+            "timeout", DEFAULT_SOCKET_TIMEOUT_SECONDS
+        )
         self.connection_class = connection_class
         self.connection_kwargs = connection_kwargs
         self.reset()
@@ -169,6 +196,7 @@ class ConnectionPool(object):
         self._available_connections = []
         self._in_use_connections = set()
 
+    @gen.coroutine
     def get_connection(self):
         """
         Get a connection from the pool
@@ -177,12 +205,18 @@ class ConnectionPool(object):
         try:
             c = self._available_connections.pop()
         except IndexError:
-            c = self.connection_class(pool=self, **self.connection_kwargs)
+            c = self.connection_class(
+                pool=self,
+                timeout=self.timeout,
+                **self.connection_kwargs
+            )
+            yield c.start()
         if c.closed():
             self.reset()
-            return self.get_connection()
-        self._in_use_connections.add(c)
-        return c
+            c = yield self.get_connection()
+        else:
+            self._in_use_connections.add(c)
+        raise gen.Return(c)
 
     def release(self, connection):
         """
@@ -193,7 +227,6 @@ class ConnectionPool(object):
         if connection in self._in_use_connections:
             self._in_use_connections.remove(connection)
             self._available_connections.append(connection)
-
 
     def disconnect(self):
         """
@@ -206,13 +239,16 @@ class ConnectionPool(object):
             connection.disconnect()
 
 
-class KafkaClient(KafkaClient):
+class KafkaClient(BaseKafkaClient):
 
     def __init__(self, *args, **kwargs):
         self._pools = {}
+        self._ready = False
+        self._starting = None
+        self.bad_topic_names = set()
         super(KafkaClient, self).__init__(*args, **kwargs)
 
-    def _get_conn(self, host, port):
+    def get_connection(self, host, port):
         """
         Get or create a connection using Pool
         :param host: host name
@@ -221,61 +257,183 @@ class KafkaClient(KafkaClient):
         """
         key = (host, port)
         if key not in self._pools:
-            self._pools[key] = ConnectionPool(host=host, port=port)
+            self._pools[key] = ConnectionPool(
+                host=host,
+                port=port,
+                retry_times=self._retry_times,
+                timeout=self.timeout
+            )
         return self._pools[key].get_connection()
 
-    @gen.async
     def boot_metadata(self, expected_topics, callback=None):
+        # This is async and will generate a future which will start up as soon
+        # as the ioloop starts up.
+        # alternately, start() can (and should) be invoked as part of
+        # initialization.
+        self.start(expected_topics)
+
+    def start(self, expected_topics=None):
+        if not self._ready:
+            if not self._starting:
+                self._starting = self.fetch_metadata(expected_topics or [])
+            return self._starting
+        f = gen.Future()
+        f.set_result(None)
+        return f
+
+    @gen.coroutine
+    def _start(self):
         """
-        boot metadata from kafka server
-        :param expected_topics: The topics to produce metadata for. If empty the request will yield metadata for all topics.
+        Once the IOLoop starts, guaranteed to only do the fetch_metadata once
+        to start, and will continue to retry for up to
+        self._retry_times * self.timeout
+        seconds at which point it'll raise a KafkaError.
+        """
+        if self._starting:
+            timeout = self._retry_times * self.timeout
+            start_time = time.time()
+            while not self._ready:
+                if time.time() - start_time > timeout:
+                    raise KafkaError(
+                        "Could not establish a connection to any backend"
+                    )
+                yield gen.sleep(.1)
+        else:
+            self._starting = True
+            yield self.fetch_metadata(self.expected_topics)
+            self.expected_topics = []
+
+    @gen.coroutine
+    def communicate(
+        self, host, port, request_bytes, correlation_id, booting=False
+    ):
+        # we'll have to communicate once on the boot sequence, in which case
+        # we'll not be ready.  Otherwise, probably best to check started.
+        if not self._ready and not booting:
+            yield self.start()
+
+        conn = yield self.get_connection(host, port)
+        with conn:
+            resp_bytes = yield conn.communicate(
+                request_bytes, correlation_id
+            )
+        if not resp_bytes:
+            log.warning(
+                "Got no response for [%r] to server %s:%i ",
+                correlation_id, host, port
+            )
+        raise gen.Return(resp_bytes)
+
+    @gen.coroutine
+    def fetch_metadata(self, expected_topics, retry_wait=1, callback=None):
+        """
+        fetch boot metadata from kafka server.  This can be invoked
+        multiple times in the case of a server configured to do
+        topic auto-creation.
+        :param expected_topics: The topics to produce metadata for.
+            If empty the request will yield metadata for all topics.
         :return:
         """
-        correlation_id, _topics, request_bytes = self._pack_boot_metadata(expected_topics)
-        for (host, port) in self.hosts*3:  # trick for auto-create topics
+
+        try:
+            expected_topics = [str(t) for t in expected_topics]
+        except UnicodeEncodeError:
+            raise TopicError("Non-ascii topic name received: %r", t)
+
+        correlation_id, _topics, request_bytes = self._pack_boot_metadata(
+            expected_topics
+        )
+
+        # give the metadata fetch up self._retry_times tries on each known host
+        for (host, port) in self.hosts * self._retry_times:
             try:
-                with self._get_conn(host, port) as conn:
-                    yield gen.task(conn.send, request_bytes, correlation_id)
-                    resp_bytes = yield gen.task(conn.recv, correlation_id)
-                self._unpack_boot_metadata(resp_bytes, expected_topics, callback)
-                return  # break the loop
+                resp_bytes = yield self.communicate(
+                    host, port,
+                    request_bytes, correlation_id,
+                    booting=True
+                )
+                if resp_bytes:
+                    self._unpack_boot_metadata(
+                        resp_bytes, expected_topics, callback
+                    )
+                    if not self._ready:
+                        self._ready = True
+                        # we can't be starting if we're ready.  Clear that
+                        self._starting = None
+                    break
             except KafkaError as e:
-                log.warning("Kafka metadata via request [%r] from server %s:%i is not available, "
-                            "trying next server: %s" % (correlation_id, host, port, e))
-                sleep(1)  # trick for auto-create topics
-                continue
+                log.warning(
+                    "Kafka metadata via request [%r] from server %s:%i "
+                    "is not available, Retrying: %s",
+                    correlation_id, host, port, e
+                )
+                # retry after a short sleep
+                yield gen.sleep(retry_wait)
             except Exception as e:
-                log.warning("Could not send request [%r] to server %s:%i, "
-                            "trying next server: %s" % (correlation_id, host, port, e))
-                continue
+                log.exception(
+                    "Could not send request [%r] to server %s:%i, "
+                    "trying next server", correlation_id, host, port
+                )
+        else:
+            raise KafkaError("All servers failed to process request")
 
-        raise KafkaError("All servers failed to process request")
+    @gen.coroutine
+    def _pack_send_message(self, topic_name, *msg):
+        if topic_name not in self.topic_to_partitions:
+            log.warning(
+                "Topic %r hasn't been seen.  Fetching metadata...",
+                topic_name
+            )
+            try:
+                yield self.fetch_metadata([topic_name])
+            except TopicError:
+                logging.exception("Couldn't auto-create topic!")
+                self.bad_topic_names.add(topic_name)
+                raise
+            else:
+                log.debug("Topic %s fetch has succeeded!", topic_name)
 
-    @gen.async
-    def send_message(self, topic_name, *msg):
-        if not self._ready:
-            def _callback():
-                self.send_message(topic_name, *msg)
-            self._add_callback(_callback)
-            return
-        host, port, request_bytes, correlation_id = self._pack_send_message(topic_name, *msg)
+        raise gen.Return(
+            super(KafkaClient, self)._pack_send_message(topic_name, *msg)
+        )
+
+    @gen.coroutine
+    def send_message(self, topic_name, *msg, **kw):
+        # because of the magic of async, we might fire send before
+        # we connect,  Hold until ready
+        while not self._ready:
+            yield gen.sleep(.1)
+
+        if topic_name in self.bad_topic_names:
+            raise TopicError(
+                "Can't write to topic %r because we failed previously" %
+                topic_name
+            )
+
+        host, port, request_bytes, correlation_id = yield self._pack_send_message(
+            topic_name, *msg
+        )
+
         for i in xrange(self._retry_times):
-            with self._get_conn(host, port) as conn:
-                try:
-                    d = yield gen.task(conn.send, request_bytes, correlation_id)
-                except ConnectionError as e:
-                    log.warning("Could not send request [%r] to server %s:%i, try again, %s" % (correlation_id, host, port, e))
-                    if i == self._retry_times - 1:
-                        log.error("Could not send request [%r] to server %s:%i, %s" % (correlation_id, host, port, e))
-                    continue  # try more
-                try:
-                    resp_bytes = yield gen.task(conn.recv, correlation_id)
-                    self._unpack_send_message(resp_bytes)
-                except ConnectionError as e:
-                    log.error('Could not get response [%r] from server %s:%i, %s' % (correlation_id, host, port, e))
-                except Exception as e:
-                    log.error("Bad response [%r] from server %s:%i, %s" % (correlation_id, host, port, e))
-            break
-
-if __name__ == "__main__":
-    pass
+            try:
+                resp_byts = yield self.communicate(
+                    host, port,
+                    request_bytes, correlation_id
+                )
+            except ConnectionError as e:
+                logger = log.warning
+                if i == self._retry_times - 1:
+                    logger = log.error
+                logger(
+                    "Could not communicate [%r] with server %s:%i, "
+                    "Retry %d of %d",
+                    correlation_id, host, port, i, self._retry,
+                    exc_info=True
+                )
+            except Exception:
+                log.exception(
+                    "Bad response [%r] from server %s:%i" %
+                    (correlation_id, host, port)
+                )
+            else:
+                break

--- a/test/mocket.py
+++ b/test/mocket.py
@@ -1,0 +1,70 @@
+import socket
+from contextlib import contextmanager
+from mock import patch
+
+from tornado import gen
+from tornado import iostream
+from StringIO import StringIO
+
+@contextmanager
+def mocket(*sock_params):
+    m = MockStream(*sock_params)
+    try:
+        p = patch("tornado.iostream.IOStream.__new__", return_value=m)
+        p.start()
+        yield m
+    finally:
+        p.stop()
+        # if self.sock and self.sock.socket:
+        #     self.sock.close()
+
+
+class MockStream(object):
+    def __init__(self, *sock_params):
+        if sock_params:
+            sock = socket.socket(*sock_params)
+            self.sock = iostream.IOStream(sock)
+        else:
+            self.sock = None
+        self._closed = True
+        self.transcript = []
+        self.response_buffer = StringIO()
+
+    def add_response(self, script):
+        assert not self.sock, "Adding responses won't work if we are proxying"
+        # rather than using write, we want to add this response to the end
+        # of the current buffer so that subsequent read()s will work
+        self.response_buffer.buf += script
+        self.response_buffer.len += len(script)
+
+    def get_transcript(self):
+        return self.transcript
+
+    @gen.coroutine
+    def connect(self, *a, **kw):
+        if self.sock and self._closed:
+            yield self.sock.connect(*a, **kw)
+        self._closed = False
+
+    @gen.coroutine
+    def close(self):
+        yield self.sock.close()
+        self._closed = True
+
+    @gen.coroutine
+    def read_bytes(self, chunk_size):
+        if self.sock:
+            res = yield self.sock.read_bytes(chunk_size)
+        else:
+            res = self.response_buffer.read(chunk_size)
+        self.transcript.append(("read", chunk_size, res))
+        raise gen.Return(res)
+
+    @gen.coroutine
+    def write(self, msg):
+        self.transcript.append(("write", len(msg), msg))
+        if self.sock:
+            yield self.sock.write(msg)
+
+    def closed(self):
+        return self.sock.closed() if self.sock else self._closed

--- a/test/test_tornado.py
+++ b/test/test_tornado.py
@@ -1,19 +1,331 @@
 # coding: utf8
+import socket
+import os
+import struct
+from nose.tools import nottest
+from tornado import gen
+from tornado.testing import AsyncTestCase, gen_test
+
+from kafkaka.define import TopicError
 from kafkaka.tornado_patch import KafkaClient
-import tornado.ioloop
+from . import mocket
 
-import time
+# This unit test was developed in Docker with access to a kafka installation
+# which has been linked to this container as `kafka`.
+#
+# Tests will still run normally without that, with the exception of
+# live_fire_test which will require some special care (and also is the test
+# used to get data for the other tests).
+KAFKA_HOST = '{}:{}'.format(
+    os.environ.get('KAFKA_PORT_9092_TCP_ADDR', "localhost"),
+    os.environ.get('KAFKA_PORT_9092_TCP_PORT', 9092)
+)
 
-if __name__ == "__main__":
-    c = KafkaClient("t-storm1:9092", topic_names=['im-msg'])
-    start = time.time()
-    print ''
-    for i in xrange(500):
-        c.send_message('im-msg', u'你好'.encode('utf8'), str(time.time()), str(i))
-        c.send_message('im-msg', 'hi', str(time.time()), str(i))
-    for i in xrange(500):
-        c.send_message('im-msg', u'你好'.encode('utf8'), str(time.time()), str(i))
-        c.send_message('im-msg', 'hi', str(time.time()), str(i))
-    print time.time() - start
-    print 'this will not block'
-    tornado.ioloop.IOLoop.instance().start()
+
+def to_kafka(payload):
+    return struct.pack('>i%ds' % len(payload), len(payload), payload)
+
+
+def add_no_topics_response(m):
+    m.add_response(
+        to_kafka(
+            '\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x05'
+            'kafka\x00\x00#\x84\x00\x00\x00\x00'
+        )
+    )
+
+
+@nottest
+def add_one_topic_test_response(m):
+    m.add_response(
+        to_kafka(
+            (
+                '\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x05'
+                'kafka\x00\x00#\x84\x00\x00\x00\x01\x00\x00\x00\x04'
+                'test\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
+                '\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00'
+                '\x01\x00\x00\x00\x01'
+            )
+        )
+    )
+    return "test"
+
+
+def add_no_such_topic_foo_response(m):
+    m.add_response(
+        to_kafka(
+            '\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x05'
+            'kafka\x00\x00#\x84\x00\x00\x00\x01\x00\x05\x00\x03foo'
+            '\x00\x00\x00\x00'
+        )
+    )
+
+
+def add_one_topic_foo_response(m):
+    m.add_response(
+        to_kafka(
+            (
+                '\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x05'
+                'kafka\x00\x00#\x84\x00\x00\x00\x01\x00\x00\x00\x03'
+                'foo\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
+                '\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00'
+                '\x01\x00\x00\x00\x01'
+            )
+        )
+    )
+    return "foo"
+
+
+class KafkaProducerTestCase(AsyncTestCase):
+
+    def assert_topics(self, client, topics):
+        self.assertEqual(
+            set(client.topic_to_partitions.keys()),
+            set(topics)
+        )
+        for topic in topics:
+            partitions = client.topic_to_partitions[topic]
+            self.assertEqual(len(partitions), 1)
+            partition = partitions[0]
+            self.assertEqual(partition.error, 0)
+            self.assertEqual(partition.partition, 0)
+            self.assertEqual(partition.leader, 1)
+            self.assertEqual(partition.replicas_number, 1)
+
+    @nottest
+    @gen_test
+    def live_fire_test(self):
+        with mocket.mocket(socket.AF_INET, socket.SOCK_STREAM, 0) as m:
+            client = KafkaClient(KAFKA_HOST)
+            yield client.start()
+            yield client.send_message("foo", "bar")
+            print client.topic_to_partitions
+            import pprint
+            pprint.pprint(m.get_transcript())
+            assert False
+
+    @nottest
+    @gen_test
+    def test_connection_fail(self):
+        with mocket.mocket() as m:
+            client = KafkaClient(KAFKA_HOST)
+            # connect is async, so give it a chance to run.
+            yield client.start()
+
+    @gen_test
+    def test_no_topics(self):
+        with mocket.mocket() as m:
+            # This says "oh hai, I don't have any topics"
+            add_no_topics_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+
+            self.assertTrue(client._ready)
+            self.assertEqual(client.topic_to_partitions, {})
+
+    @gen_test
+    def test_no_topics_multi_start(self):
+        with mocket.mocket() as m:
+            # This says "oh hai, I don't have any topics"
+            add_no_topics_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # start should be able to be run as many times as
+            # we want
+            for _ in range(3):
+                yield client.start()
+                yield gen.sleep(.5)
+
+            self.assertTrue(client._ready)
+            self.assertEqual(client.topic_to_partitions, {})
+
+    @gen_test
+    def test_topics(self):
+        with mocket.mocket() as m:
+            # This says "I have one topic named 'test'" with a
+            # replication-factor" of 1 and 1 partition
+            topic_name = add_one_topic_test_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+    @gen_test
+    def test_topics_unicode(self):
+        with mocket.mocket() as m:
+            # This says "I have one topic named 'test'" with a
+            # replication-factor" of 1 and 1 partition
+            topic_name = add_one_topic_test_response(m)
+
+            # Kafkaclient uses struct, and struct expects strings
+            client = KafkaClient(
+                KAFKA_HOST, topic_names=[unicode(topic_name)],
+                timeout=1
+            )
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+    @gen_test
+    def test_topics_unicode_fail(self):
+        with mocket.mocket() as m:
+            # This says "I have one topic named 'test'" with a
+            # replication-factor" of 1 and 1 partition
+            topic_name = add_one_topic_test_response(m)
+
+            # Kafkaclient uses struct, and struct expects strings
+            try:
+                client = KafkaClient(
+                    KAFKA_HOST, topic_names=[u"touché"],
+                    timeout=1
+                )
+                yield client.start()
+            except TopicError:
+                pass
+            else:
+                assert False, "Should have raised on non-ascii topic"
+            self.assertFalse(client._ready)
+
+
+    @gen_test
+    def test_produce(self):
+        with mocket.mocket() as m:
+            topic_name = add_one_topic_test_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+            yield client.send_message(topic_name, topic_name)
+
+            # that shouldn't have broken the client
+            self.assertTrue(client._ready)
+            self.assert_topics(client, [topic_name])
+
+    @gen_test
+    def test_multiproduce_bad_unicode(self):
+        with mocket.mocket() as m:
+            topic_name = add_one_topic_test_response(m)
+            unicode_topic = u"touché"
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+            try:
+                yield client.send_message(unicode_topic, "test")
+            except TopicError:
+                pass
+            else:
+                assert False, "Should have raised on non-ascii topic"
+
+            # the broken message shouldn't affect subsequent messages
+            yield client.send_message(topic_name, "test")
+
+            # that shouldn't have broken the client
+            self.assertTrue(client._ready)
+            self.assert_topics(client, [topic_name])
+
+            # also we should have blacklisted this topic name
+            self.assertTrue(client.bad_topic_names, set([unicode_topic]))
+
+    @gen_test
+    def test_multiproduce(self):
+        with mocket.mocket() as m:
+            topic_name = add_one_topic_test_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+            yield client.send_message(topic_name, topic_name)
+            yield client.send_message(topic_name, topic_name)
+            yield client.send_message(topic_name, topic_name)
+
+            # that shouldn't have broken the client
+            self.assertTrue(client._ready)
+            self.assert_topics(client, [topic_name])
+
+    @gen_test
+    def test_produce_autocreate(self):
+        with mocket.mocket() as m:
+            # We're going to be responding as follows:
+            #  1) I have a topic 'test' (metadata request)
+            #  2) What's a 'foo'? [kafka autocreates, client retries]
+            #  3) Oh right!  'foo'!  Here you go [success]
+            topic_name = add_one_topic_test_response(m)
+            add_no_such_topic_foo_response(m)
+            new_topic = add_one_topic_foo_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+            yield client.send_message(new_topic, topic_name)
+
+            # that shouldn't have broken the client
+            self.assertTrue(client._ready)
+            # There should now be 2 topics
+            self.assert_topics(client, [topic_name, new_topic])
+
+    @gen_test
+    def test_produce_no_autocreate(self):
+        with mocket.mocket() as m:
+            # We're going to be responding as follows:
+            #  1) I have a topic 'test' (metadata request)
+            #  2) What's a 'foo'? [kafka autocreates, client retries]
+            #  2') What's a 'foo'? [kafka autocreates, client retries]
+            #  2'') What's a 'foo'? [kafka autocreates, client retries]
+            #  3) client aborts.
+            topic_name = add_one_topic_test_response(m)
+            add_no_such_topic_foo_response(m)
+            add_no_such_topic_foo_response(m)
+            add_no_such_topic_foo_response(m)
+
+            client = KafkaClient(KAFKA_HOST)
+
+            # connect is async, so give it a chance to run.
+            yield client.start()
+            self.assertTrue(client._ready)
+            # there should be a single topic
+            self.assert_topics(client, [topic_name])
+
+            try:
+                yield client.send_message("foo", "test")
+            except:
+                pass
+            else:
+                assert False, "Should have raised a KafkaError"
+
+            # that shouldn't have broken the client
+            self.assertTrue(client._ready)
+            # There should now be
+            self.assert_topics(client, [topic_name])


### PR DESCRIPTION
In the process adds:
- add unit tests which can be run via nose without the need of a running Kafka
- added `test/mocket.py` for both mocking out and (optionally) snooping on traffic sent to IOStream
- handle topic autocreation via metadata fetch and retry
- add 'locking' around the read/write process to ensure the response order is kept in sync
- break cleanly on unicode topic names (since kafka has a restricted set of topic names anyway)

Also apologies for any whitespace fiddling: I generally develop with auto-pep8 running and it can be a little overzealous. 

Also let me know if you rather I pulled some of these changes up into the main `KafkaClient`.  I'd be happy to do it in a subsequent patch as well.  We use tornado heavily, but non-async is definitely easier to test.  I also think that at least for the tornado client, the explicit `callback` structure in the sync client isn't strictly necessary, as this patch doesn't make use of any of it.  
